### PR TITLE
ENH: inverse_transform now reverts original columns info

### DIFF
--- a/doc/source/sklearn.rst
+++ b/doc/source/sklearn.rst
@@ -136,7 +136,7 @@ Thus, you can instanciate each estimator via ``ModelFrame`` accessors. Once crea
 
 .. note:: If you access to a property before calling ``ModelFrame`` methods, ``ModelFrame`` automatically calls corresponding method of the latest estimator and return the result.
 
-Following example shows to perform PCA, then revert principal components back to original space.
+Following example shows to perform PCA, then revert principal components back to original space. ``inverse_transform`` should revert the original columns.
 
 .. code-block:: python
 
@@ -156,23 +156,21 @@ Following example shows to perform PCA, then revert principal components back to
    <class 'pandas_ml.core.frame.ModelFrame'>
 
    >>> transformed.inverse_transform(estimator)
-        .target    0    1    2    3
-   0          0  5.1  3.5  1.4  0.2
-   1          0  4.9  3.0  1.4  0.2
-   2          0  4.7  3.2  1.3  0.2
-   3          0  4.6  3.1  1.5  0.2
-   4          0  5.0  3.6  1.4  0.2
-   ..       ...  ...  ...  ...  ...
-   145        2  6.7  3.0  5.2  2.3
-   146        2  6.3  2.5  5.0  1.9
-   147        2  6.5  3.0  5.2  2.0
-   148        2  6.2  3.4  5.4  2.3
-   149        2  5.9  3.0  5.1  1.8
+        .target  sepal length  sepal width  petal length  petal width
+   0          0           5.1          3.5           1.4          0.2
+   1          0           4.9          3.0           1.4          0.2
+   2          0           4.7          3.2           1.3          0.2
+   3          0           4.6          3.1           1.5          0.2
+   4          0           5.0          3.6           1.4          0.2
+   ..       ...           ...          ...           ...          ...
+   145        2           6.7          3.0           5.2          2.3
+   146        2           6.3          2.5           5.0          1.9
+   147        2           6.5          3.0           5.2          2.0
+   148        2           6.2          3.4           5.4          2.3
+   149        2           5.9          3.0           5.1          1.8
 
    [150 rows x 5 columns]
 
-
-.. note:: ``columns`` information will be lost once transformed to principal components.
 
 If ``ModelFrame`` both has ``target`` and ``predicted`` values, the model evaluation can be performed using functions available in ``ModelFrame.metrics``.
 

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -2,6 +2,14 @@
 What's new
 ==========
 
+v0.3.1
+------
+
+Enhancement
+^^^^^^^^^^^
+
+- ``inverse_transform`` now reverts original ``ModelFrame.columns`` information.
+
 v0.3.0
 ------
 

--- a/pandas_ml/core/generic.py
+++ b/pandas_ml/core/generic.py
@@ -65,8 +65,10 @@ class ModelTransformer(object):
               dict(funcname='transform', returned='returned : transformed result'))
     def transform(self, estimator, *args, **kwargs):
         if isinstance(estimator, compat.string_types):
+            # transform using patsy
             return misc.transform_with_patsy(estimator, self, *args, **kwargs)
 
+        # whether to delegate AccessorMethods.transform
         mapped = self._get_method_mapper(estimator, 'transform')
         if mapped is not None:
             result = mapped(self, estimator, *args, **kwargs)
@@ -87,7 +89,8 @@ class ModelTransformer(object):
               dict(funcname='inverse_transform', returned='returned : transformed result'))
     def inverse_transform(self, estimator, *args, **kwargs):
         transformed = self._call(estimator, 'inverse_transform', *args, **kwargs)
-        return self._wrap_transform(transformed)
+        transformed = self._wrap_transform(transformed)
+        return transformed
 
     def _wrap_transform(self, transformed):
         raise NotImplementedError

--- a/pandas_ml/core/series.py
+++ b/pandas_ml/core/series.py
@@ -24,7 +24,7 @@ class ModelSeries(pd.Series, ModelTransformer):
         result = method(data, *args, **kwargs)
         return result
 
-    def _wrap_transform(self, transformed):
+    def _wrap_transform(self, transformed, columns=None):
         """
         Wrapper for transform methods
         """

--- a/pandas_ml/skaccessors/test/test_decomposition.py
+++ b/pandas_ml/skaccessors/test/test_decomposition.py
@@ -183,6 +183,7 @@ class TestDecomposition(tm.TestCase):
             self.assertTrue(isinstance(result, pdml.ModelFrame))
             self.assert_series_equal(df.target, result.target)
             self.assert_numpy_array_almost_equal(result.data.values, expected)
+            self.assert_index_equal(result.columns, df.columns)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
```
import sklearn.datasets as datasets

df = pdml.ModelFrame(datasets.load_iris())
df.columns = ['.target', 'sepal length', 'sepal width', 'petal length', 'petal width']

estimator = df.decomposition.PCA()
df.fit(estimator)
# PCA(copy=True, n_components=None, whiten=False)

transformed = df.transform(estimator)
transformed.head()
#    .target         0         1         2         3
# 0        0 -2.684207 -0.326607  0.021512  0.001006
# 1        0 -2.715391  0.169557  0.203521  0.099602
# 2        0 -2.889820  0.137346 -0.024709  0.019305
# 3        0 -2.746437  0.311124 -0.037672 -0.075955
# 4        0 -2.728593 -0.333925 -0.096230 -0.063129


transformed.inverse_transform(estimator).head()
#      .target  sepal length  sepal width  petal length  petal width
# 0          0           5.1          3.5           1.4          0.2
# 1          0           4.9          3.0           1.4          0.2
# 2          0           4.7          3.2           1.3          0.2
# 3          0           4.6          3.1           1.5          0.2
# 4          0           5.0          3.6           1.4          0.2
```