### PR TITLE
BUG: Unable to assign Series to ModelFrame.data

### DIFF
--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -10,6 +10,11 @@ Enhancement
 
 - ``inverse_transform`` now reverts original ``ModelFrame.columns`` information.
 
+Bug Fix
+^^^^^^^
+
+- Assigning ``Series`` to ``ModelFrame.data`` property raises ``TypeError``
+
 v0.3.0
 ------
 

--- a/pandas_ml/core/frame.py
+++ b/pandas_ml/core/frame.py
@@ -227,6 +227,13 @@ class ModelFrame(pd.DataFrame, ModelPredictor):
             if data.has_target():
                 msg = 'Cannot update with {0} which has target attribute'
                 raise ValueError(msg.format(self.__class__.__name__))
+        elif isinstance(data, pd.Series):
+            data = data.to_frame()
+        elif isinstance(data, pd.DataFrame):
+            pass
+        else:
+            msg = 'data must be ModelFrame, ModelSeries, DataFrame or Series, {0} passed'
+            raise TypeError(msg.format(data.__class__.__name__))
 
         data, _ = self._maybe_convert_data(data, self.target, self.target_name)
 

--- a/pandas_ml/test/test_frame.py
+++ b/pandas_ml/test/test_frame.py
@@ -327,6 +327,34 @@ class TestModelFrame(tm.TestCase):
         self.assertEqual(mdf.target.name, '.target')
         self.assertEqual(mdf.target_name, '.target')
 
+    def test_frame_data_proparty_series(self):
+        df = pdml.ModelFrame({'A': [1, 2, 3],
+                              'B': [4, 5, 6]},
+                             target=[7, 8, 9],
+                             index=['a', 'b', 'c'])
+        df.data = df['A']
+        exp = pdml.ModelFrame({'A': [1, 2, 3]},
+                              target=[7, 8, 9],
+                              index=['a', 'b', 'c'])
+        self.assert_frame_equal(df, exp)
+
+        df = pdml.ModelFrame({'A': [1, 2, 3],
+                              'B': [4, 5, 6]},
+                             target=[7, 8, 9],
+                             index=['a', 'b', 'c'])
+        df.data = pd.Series([1, 2, 3], name='x', index=['a', 'b', 'c'])
+        exp = pdml.ModelFrame({'x': [1, 2, 3]},
+                              target=[7, 8, 9],
+                              index=['a', 'b', 'c'])
+        self.assert_frame_equal(df, exp)
+
+        df = pdml.ModelFrame({'A': [1, 2, 3],
+                              'B': [4, 5, 6]},
+                             target=[7, 8, 9],
+                             index=['a', 'b', 'c'])
+        with tm.assertRaises(TypeError):
+            df.data = [1, 2, 3]
+
     def test_frame_target_proparty(self):
         df = pd.DataFrame({'A': [1, 2, 3],
                            'B': [4, 5, 6],


### PR DESCRIPTION
```
import numpy as np
import pandas_ml as pdml
df = pdml.ModelFrame({'a': [1, 2, 3], 'b': [3, 4, 5]},
                     target=[1, 2, 3])
df
#    .target  a  b
# 0        1  1  3
# 1        2  2  4
# 2        3  3  5

df.data = df['a']
# TypeError: __init__() got multiple values for keyword argument 'index'
```